### PR TITLE
DM-31998: Performance tuning

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: rubintv
 spec:
-  replicas: 1
+  replicas: 5
   selector:
     matchLabels:
       name: rubintv

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
   - name: lsstsqre/rubintv
-    newTag: 0.0.10
+    newTag: 0.0.11
 
 resources:
   - configmap.yaml

--- a/src/rubintv/static/js/refresh.js
+++ b/src/rubintv/static/js/refresh.js
@@ -4,6 +4,6 @@ $(document).ready(function () {
 
 function refreshDiv() {
   $('#refresher').load(window.location.href + ' #refresher', function () {
-    setTimeout(refreshDiv, 10000);
+    setTimeout(refreshDiv, 5000);
   });
 }

--- a/src/rubintv/static/js/refresh.js
+++ b/src/rubintv/static/js/refresh.js
@@ -1,9 +1,9 @@
-$(document).ready(function(){
-      refreshDiv();
-    });
+$(document).ready(function () {
+  refreshDiv();
+});
 
-    function refreshDiv(){
-        $('#refresher').load(window.location.href + " #refresher" , function(){
-           setTimeout(refreshDiv, 500);
-        });
-    }
+function refreshDiv() {
+  $('#refresher').load(window.location.href + ' #refresher', function () {
+    setTimeout(refreshDiv, 10000);
+  });
+}

--- a/src/rubintv/timer.py
+++ b/src/rubintv/timer.py
@@ -1,0 +1,23 @@
+"""Basic timing utility."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+__all__ = ["Timer"]
+
+
+class Timer:
+    """Time a context.
+
+    Access the duration after the context exits with the ``seconds``
+    attribute.
+    """
+
+    def __enter__(self) -> Timer:
+        self._start = time.perf_counter()
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        self.seconds = time.perf_counter() - self._start


### PR DESCRIPTION
This PR resolves performance issues seen in Rubin TV's Roundtable deployment. Because querying all objects in the GCS bucket is fairly slow (>1 second), multiple requests can pile up and easily trigger what is effectively denial-of-service attack. The fixes:

- The auto-refresh JavaScript was set to 0.5 seconds. Here I've backed off the refresh period to 10 seconds to prevent a single client from creating a backlog of requests.
- I've updated the Kubernetes deployment with a replication factor of 5. More replicas mean that more pods can service requests at the same time.
- I noticed that rubintv wasn't logging anything; I've added a simple Timer context manager and a log statement to each request handler to make it easier to monitor requests and response times.