### PR TITLE
DM-37164 Build image on develop branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,18 +1,18 @@
 name: CI
 
-"on":
+'on':
   push:
     branches-ignore:
       # These should always correspond to pull requests, so ignore them for
       # the push trigger and let them be triggered by the pull_request
       # trigger, avoiding running the workflow twice.  This is a minor
       # optimization so there's no need to ensure this is comprehensive.
-      - "dependabot/**"
-      - "renovate/**"
-      - "tickets/**"
-      - "u/**"
+      - 'dependabot/**'
+      - 'renovate/**'
+      - 'tickets/**'
+      - 'u/**'
     tags:
-      - "*"
+      - '*'
   pull_request: {}
 
 jobs:
@@ -22,8 +22,8 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.9"
-          - "3.10"
+          - '3.9'
+          - '3.10'
 
     steps:
       - uses: actions/checkout@v3
@@ -59,7 +59,7 @@ jobs:
       - name: Run tox
         run: tox -e py,coverage-report,typing
         env:
-           GOOGLE_APPLICATION_CREDENTIALS: "/tmp/google_creds.json"
+          GOOGLE_APPLICATION_CREDENTIALS: '/tmp/google_creds.json'
 
   build:
     runs-on: ubuntu-latest
@@ -71,8 +71,8 @@ jobs:
     # but in this case the build will fail with an error since the secret
     # won't be set.
     if: >
-      startsWith(github.ref, 'refs/tags/')
-      || startsWith(github.head_ref, 'tickets/')
+      startsWith(github.ref, 'refs/tags/') || startsWith(github.head_ref, 'tickets/') || startsWith(github.head_ref, 'develop')
+
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Previously the docker image was only built for tags or tickets/ branches. Also build for the "develop" git ref as well to support building images for the development instance of rubin tv.