### PR TITLE
DM-37164: Fix build trigger for develop branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
     # but in this case the build will fail with an error since the secret
     # won't be set.
     if: >
-      startsWith(github.ref, 'refs/tags/') || startsWith(github.head_ref, 'tickets/') || startsWith(github.ref, 'develop')
+      startsWith(github.ref, 'refs/tags/') || startsWith(github.head_ref, 'tickets/') || startsWith(github.ref, 'refs/heads/develop')
 
 
     steps:


### PR DESCRIPTION
This should finally build Docker images for the `develop` branch.